### PR TITLE
Added SSL to docker-compose

### DIFF
--- a/micro-deployment/scripts/wordpress.yaml
+++ b/micro-deployment/scripts/wordpress.yaml
@@ -20,6 +20,7 @@ services:
     image: wordpress:latest
     ports:
       - "80:80"
+      - "443:443"
     restart: always
     environment:
       WORDPRESS_DB_HOST: db:3306


### PR DESCRIPTION
For production deployments, we need to have docker port mapping for SSL (port 443).