### PR TITLE
Support VM.Standard.A1.Flex in micro deployment

### DIFF
--- a/micro-deployment/README.md
+++ b/micro-deployment/README.md
@@ -43,14 +43,24 @@ region = "<oci_region>"
 # Availablity Domain 
 availablity_domain_name = "<availablity_domain_name>"
 
+# WordPress Admin Password
+wp_admin_password = "<wp_admin_password>"
 ```
 
-You also need to uncomment the following lines in the `provider.tf`.
+You need to uncomment the following lines in the `provider.tf`.
 ```
    user_ocid = var.user_ocid
    fingerprint = var.fingerprint
    private_key_path = var.private_key_path
 ```
+
+You also need to uncomment the following lines in the `variables.tf`.
+```
+   variable "fingerprint" {}
+   variable "private_key_path" {}
+   variable "user_ocid" {}
+```
+
 ### Create the Resources
 Run the following commands:
 

--- a/micro-deployment/outputs.tf
+++ b/micro-deployment/outputs.tf
@@ -11,4 +11,5 @@ output "wordpress_admin_url" {
 
 output "generated_ssh_private_key" {
   value = tls_private_key.public_private_key_pair.private_key_pem
+  sensitive = true
 }

--- a/micro-deployment/scripts/wordpress.yaml
+++ b/micro-deployment/scripts/wordpress.yaml
@@ -4,7 +4,7 @@
 version: '3.3'
 services:
   db:
-    image: mysql:5.7
+    image: mysql:8.0
     volumes:
       - db_data:/var/lib/mysql
     restart: always

--- a/micro-deployment/scripts/wordpress.yaml
+++ b/micro-deployment/scripts/wordpress.yaml
@@ -4,7 +4,7 @@
 version: '3.3'
 services:
   db:
-    image: mysql:8.0
+    image: mysql/mysql-server:8.0
     volumes:
       - db_data:/var/lib/mysql
     restart: always

--- a/micro-deployment/wordpress.tf
+++ b/micro-deployment/wordpress.tf
@@ -122,6 +122,6 @@ resource "random_password" "wp_db_password" {
 locals {
   availability_domain_name   = var.availability_domain_name != null ? var.availability_domain_name : data.oci_identity_availability_domains.ADs.availability_domains[0].name
   instance_shape             = var.instance_shape
-  compute_flexible_shapes    = ["VM.Standard.E3.Flex","VM.Standard.E4.Flex"]
+  compute_flexible_shapes    = ["VM.Standard.E3.Flex","VM.Standard.E4.Flex","VM.Standard.A1.Flex"]
   is_flexible_instance_shape = contains(local.compute_flexible_shapes, local.instance_shape)
 }


### PR DESCRIPTION
This PR adds support for VM.Standard.A1.Flex to the micro deployment.

This does require upgrading from MySQL 5.7 to 8.0 and using the mysql/mysql-server image maintained by Oracle instead of the mysql image as that image does not support ARM.

It also marks the ssh private key as sensitive so that the code runs on Terraform 1.0 without error.